### PR TITLE
Fix compiler warnings

### DIFF
--- a/test/ken_server_test.erl
+++ b/test/ken_server_test.erl
@@ -12,8 +12,6 @@
 
 -module(ken_server_test).
 
--compile([export_all]).
-
 -include_lib("eunit/include/eunit.hrl").
 
 %% hardcoded defaults: limit: 20; batch: 1; delay: 5000; prune: 60000


### PR DESCRIPTION
- Replace use of `erlang:now/0` with `erlang:monotonic_time/0`
- Replace use of `random` module with `rand` module