### PR TITLE
Detect dreyfus/hastings correctly

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -10,8 +10,8 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
-HaveDreyfus = code:lib_dir(dreyfus) /= {error, bad_name}.
-HaveHastings = code:lib_dir(hastings) /= {error, bad_name}.
+HaveDreyfus = element(1, file:list_dir("../dreyfus")) == ok.
+HaveHastings = element(1, file:list_dir("../hastings")) == ok.
 
 CurrOpts = case lists:keyfind(erl_opts, 1, CONFIG) of
     {erl_opts, Opts} -> Opts;


### PR DESCRIPTION
The code:lib_dir test only works if those projects are compiled first,
which is not guaranteed.